### PR TITLE
Fix broken url to Mayan EDMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <p>
     If you find Open Paperless useful please support me via <a href="https://www.patreon.com/zhoubear">Patreon</a>.
-    You can also support Mayan EDMS via their website at <a href="www.mayan-edms.com">www.mayan-edms.com</a>.
+    You can also support Mayan EDMS via their website at <a href="https://www.mayan-edms.com">www.mayan-edms.com</a>.
 </p>
 
 </div>


### PR DESCRIPTION
Used to link to:
`https://github.com/zhoubear/open-paperless/blob/master/www.mayan-edms.com`
Will now link to:
`https://www.mayan-edms.com`